### PR TITLE
Updates to make three.csg work with newer Dart and three.dart

### DIFF
--- a/example/sample.dart
+++ b/example/sample.dart
@@ -1,15 +1,15 @@
 import "dart:html";
 import 'package:threecsg/threecsg.dart';
 import 'package:three/three.dart' as THREE;
-import 'package:three/extras/controls/trackball.dart' as THREE;
+import 'package:three/extras/controls/trackball_controls.dart';
 
 var renderer, scene, camera, controls;
 
 /// Example #1 - Cube (mesh) subtract Sphere (mesh)
 example1() {
-  var cube_geometry = new THREE.CubeGeometry( 3, 3, 3 );
+  var cube_geometry = new THREE.CubeGeometry( 3.0, 3.0, 3.0 );
   var cube_mesh = new THREE.Mesh( cube_geometry );
-  cube_mesh.position.x = -10;
+  cube_mesh.position.x = -10.0;
   var cube_bsp = new BSP( cube_mesh );
 
   var sphere_geometry = new THREE.SphereGeometry( 1.8, 20, 20 );
@@ -24,10 +24,10 @@ example1() {
 
 /// Example #2 - Sphere (geometry) union Cube (geometry)
 example2() {
-  var sphere_geometry = new THREE.SphereGeometry( 2, 20, 20 );
+  var sphere_geometry = new THREE.SphereGeometry( 2.0, 20, 20 );
   var sphere_bsp = new BSP( sphere_geometry );
 
-  var cube_geometry = new THREE.CubeGeometry( 7, .5, 3 );
+  var cube_geometry = new THREE.CubeGeometry( 7.0, 0.5, 3.0 );
   var cube_bsp = new BSP( cube_geometry );
 
   var union_bsp = sphere_bsp.union( cube_bsp );
@@ -39,18 +39,18 @@ example2() {
 
 // Example #3 - Sphere (geometry) intersect Sphere (mesh)
 example3() {
-  var sphere_geometry_1 = new THREE.SphereGeometry( 2, 20, 20 );
+  var sphere_geometry_1 = new THREE.SphereGeometry( 2.0, 20, 20 );
   var sphere_bsp_1 = new BSP( sphere_geometry_1 );
 
-  var sphere_geometry_2 = new THREE.SphereGeometry( 2, 20, 20 );
+  var sphere_geometry_2 = new THREE.SphereGeometry( 2.0, 20, 20 );
   var sphere_mesh_2 = new THREE.Mesh( sphere_geometry_2 );
-  sphere_mesh_2.position.x = 2;
+  sphere_mesh_2.position.x = 2.0;
   var sphere_bsp_2 = new BSP( sphere_mesh_2 );
 
   var intersect_bsp = sphere_bsp_1.intersect( sphere_bsp_2 );
 
   var result_mesh = intersect_bsp.toMesh( new THREE.MeshNormalMaterial() );
-  result_mesh.position.x = 10;
+  result_mesh.position.x = 10.0;
   scene.add( result_mesh );
 }
 
@@ -65,29 +65,29 @@ main() {
 
   renderer = new THREE.WebGLRenderer(); //{antialias: true});
   renderer.setSize( window.innerWidth, window.innerHeight );
-  document.query('#viewport').elements.add(renderer.domElement);
+  document.querySelector('#viewport').children.add(renderer.domElement);
 
   scene = new THREE.Scene();
 
-  camera = new THREE.PerspectiveCamera(35, window.innerWidth / window.innerHeight, 10, 100);
-  camera.position.setValues(0, 10, 15);
+  camera = new THREE.PerspectiveCamera(35.0, window.innerWidth / window.innerHeight, 10.0, 100.0);
+  camera.position.setValues(0.0, 10.0, 15.0);
   camera.lookAt(scene.position);
 
   example1();
   example2();
   example3();
-  
-  controls = new THREE.TrackballControls( camera, renderer.domElement )
+
+  controls = new TrackballControls( camera, renderer.domElement )
   ..rotateSpeed = 0.5
   ..addEventListener( 'change', (_) => render() );
-  
+
   animate(0);
 
 }
 
 /// Test #1 - Cube (mesh)
 test1() {
-  var cube_geometry = new THREE.CubeGeometry( 3, 3, 3 );
+  var cube_geometry = new THREE.CubeGeometry( 3.0, 3.0, 3.0 );
   var cube_mesh = new THREE.Mesh( cube_geometry );
   var cube_bsp = new BSP( cube_mesh );
 
@@ -96,7 +96,7 @@ test1() {
 
 /// Test #2 - Sphere
 test2() {
-  var sphere_geometry = new THREE.SphereGeometry( 3);
+  var sphere_geometry = new THREE.SphereGeometry( 3.0);
   var sphere_mesh = new THREE.Mesh( sphere_geometry );
   var sphere_bsp = new BSP( sphere_mesh );
 
@@ -105,9 +105,9 @@ test2() {
 
 /// Test #3 - Transform
 test3() {
-  var cube_geometry = new THREE.CubeGeometry( 3, 3, 3 );
+  var cube_geometry = new THREE.CubeGeometry( 3.0, 3.0, 3.0 );
   var cube_mesh = new THREE.Mesh( cube_geometry, new THREE.MeshNormalMaterial() );
-  cube_mesh.translateX(-10);
+  cube_mesh.translateX(-10.0);
   var cube_bsp = new BSP( cube_mesh );
   scene.add(cube_bsp.toMesh( new THREE.MeshNormalMaterial() ));
 }

--- a/example/sample.html
+++ b/example/sample.html
@@ -12,6 +12,6 @@
 	<body>
 		<div id="viewport"></div>
 		<script type="application/dart" src="sample.dart"></script>
-	    <script src="http://dart.googlecode.com/svn/branches/bleeding_edge/dart/client/dart.js"></script>
+	  <script src="packages/browser/dart.js"></script>
 	</body>
 </html>

--- a/lib/threecsg.dart
+++ b/lib/threecsg.dart
@@ -21,5 +21,6 @@ library threecsg;
 
 import "package:csg/csg.dart" as CSG;
 import 'package:three/three.dart' as THREE;
+import 'package:vector_math/vector_math.dart';
 
 part "src/bsp.dart";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ authors:
 - Tiago Cardoso <tiago.cardoso@inevo.pt>
 homepage: https://github.com/threeDart/three.csg.dart
 dependencies:
+  browser: any
   three:
     git: git://github.com/threeDart/three.dart.git
   csg:


### PR DESCRIPTION
This pull request includes fixes where Dart is expecting more explicit double as opposed to int and updates to make three.csg.dart work with the latest three.dart APIs.

These changes also depend on my pull request in csg.dart to be accepted as that has a couple of map().toList() calls missing as well.

To give credit where it's due, these changes are based on a previous pull request here: https://github.com/threeDart/three.csg.dart/pull/2

I've cleaned up the formatting and squashed the commits into a single commit and put everything into a branch.
